### PR TITLE
New emittance coupling calculation

### DIFF
--- a/pyaccel/optics.py
+++ b/pyaccel/optics.py
@@ -345,12 +345,14 @@ def calc_emittance_coupling(accelerator,
         n = _np.argmax(_np.abs(E))
         a = V[:, n]
         b, c, d, f, g, a = a[1]/2, a[2], a[3]/2, a[4]/2, a[5], a[0]
-        up = 2*(a*f*f + c*d*d + g*b*b - 2*b*d*f - a*c*g)
-        down1 = (b*b-a*c) * ((c-a) * _np.sqrt(1 + 4*b*b / ((a-c)*(a-c)))-(c+a))
-        down2 = (b*b-a*c) * ((a-c) * _np.sqrt(1 + 4*b*b / ((a-c)*(a-c)))-(c+a))
-        res1 = _np.sqrt(up/down1)
-        res2 = _np.sqrt(up/down2)
-        return _np.array([res1, res2])  # returns the axes of the ellipse
+        numerator = 2*(a*f*f + c*d*d + g*b*b - 2*b*d*f - a*c*g)
+        denominator1 = (b*b-a*c) * ((c-a) * _np.sqrt(
+            1 + 4*b*b / ((a-c)*(a-c)))-(c+a))
+        denominator2 = (b*b-a*c) * ((a-c) * _np.sqrt(
+            1 + 4*b*b / ((a-c)*(a-c)))-(c+a))
+        axis1 = _np.sqrt(numerator/denominator1)
+        axis2 = _np.sqrt(numerator/denominator2)
+        return _np.array([axis1, axis2])  # returns the axes of the ellipse
 
     def calc_emittances(orbit, twiss, idx=0):
         alphax = twiss.alphax[idx]

--- a/pyaccel/optics.py
+++ b/pyaccel/optics.py
@@ -331,8 +331,10 @@ def calc_emittance_coupling(accelerator,
                             mode='fitting',
                             x0=1e-5, y0=1e-8,
                             nr_turns=100):
-    # I copied the code below from:
+    # Code copied from:
     # http://nicky.vanforeest.com/misc/fitEllipse/fitEllipse.html
+    # In order to check the nomenclature used, please go to:
+    # https://mathworld.wolfram.com/Ellipse.html
     def fitEllipse(x, y):
         x = x[:, _np.newaxis]
         y = y[:, _np.newaxis]


### PR DESCRIPTION
- Emittance coupling calculation via twiss functions
- This mode is slower than the elipse fitting since calculates the twiss parameters
- The results obtained from both methods differs by aprox. 15% (for a model fitted with LOCO using normal and skew gradients). A systematic study to check which method is more reliable still must be done.
- By now, the aim of this PR is just to add a new way to calculate emittance coupling.