### PR TITLE
Makes naff accepts signal of any size and doc string correction

### DIFF
--- a/pyaccel/naff.py
+++ b/pyaccel/naff.py
@@ -1,8 +1,8 @@
 """NAFF module
 This module performs the Numerical Analysis of Fundamental Frequencies (NAFF)
-method, developed by J. Naskar in:
+method, developed by J. Laskar in:
 
-J. Naskar, The chaotic motion of the solar system: A numerical estimate of the
+J. Laskar, The chaotic motion of the solar system: A numerical estimate of the
 size of the chaotic zones, Icarus, Volume 88, Issue 2,1990, Pages 266-291.
 (https://www.sciencedirect.com/science/article/pii/001910359090084M)
 """
@@ -65,5 +65,7 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
 
     if is_real:
         freqs = _np.abs(freqs)
+        mask = freqs > 0.5
+        freqs[mask] = _np.abs(1-freqs[mask])
 
     return freqs, fourier

--- a/pyaccel/naff.py
+++ b/pyaccel/naff.py
@@ -62,4 +62,8 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
     fourier = real + 1j*imag
     fourier = _np.squeeze(fourier)
     freqs = _np.squeeze(freqs)
+
+    if is_real:
+        freqs = _np.abs(freqs)
+
     return freqs, fourier

--- a/pyaccel/naff.py
+++ b/pyaccel/naff.py
@@ -35,8 +35,8 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
     Outputs:
         freqs -- fundamental frequencies.
             Numpy array with shape `(signal.shape[0], nr_ff)`.
-            In case is_real is true, only positive frequencies in the interval
-            [0, 0.5] are returned;
+            In case is_real is True, only one component of each frequency,
+            the positive or negative part is returned;
         fourier -- Fourier component of the given frequencies.
             Numpy array of complex numbers with same shape as freqs.
     """
@@ -48,7 +48,7 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
 
     if (signal.shape[1]-1) % 6:
         q, r = divmod(signal.shape[1], 6)
-        if r == 0:
+        if not r:
             q -= 1
         q = 6*q+1
         signal = signal[:, :q]
@@ -62,10 +62,5 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
     fourier = real + 1j*imag
     fourier = _np.squeeze(fourier)
     freqs = _np.squeeze(freqs)
-
-    if is_real:
-        freqs = _np.abs(freqs)
-        mask = freqs > 0.5
-        freqs[mask] = _np.abs(1-freqs[mask])
 
     return freqs, fourier

--- a/pyaccel/naff.py
+++ b/pyaccel/naff.py
@@ -1,16 +1,10 @@
-"""Pyaccel tracking module.
+"""NAFF module
+This module performs the Numerical Analysis of Fundamental Frequencies (NAFF)
+method, developed by J. Naskar in:
 
-This module concentrates all tracking routines of the accelerator.
-Most of them take a structure called 'positions' as an argument which
-should store the initial coordinates of the particle, or the bunch of particles
-to be tracked. Most of these routines generate tracked particle positions as
-output, among other data. These input and ouput particle positions are stored
-as native python lists or numpy arrays. Depending on the routine these position
-objects may have one, two, three or four indices. These indices are used to
-select particle's inices (p), coordinates(c), lattice element indices(e) or
-turn number (n). For example, v = pos[p,c,e,n]. Routines in these module may
-return particle positions structure missing one or more indices but the
-PCEN ordering is preserved.
+J. Naskar, The chaotic motion of the solar system: A numerical estimate of the
+size of the chaotic zones, Icarus, Volume 88, Issue 2,1990, Pages 266-291.
+(https://www.sciencedirect.com/science/article/pii/001910359090084M)
 """
 
 import numpy as _np
@@ -35,7 +29,7 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
         nr_ff -- Number of fundamental frequencies to return (default = 2);
         window -- Which window to use:  (default = 1)
             0 -- no window;
-            1, 2, 3, ... -- Powers of hanning window;
+            1, 2, 3, ... -- Powers of Hamming window;
             -1 -- Exponential window;
 
     Outputs:
@@ -53,7 +47,11 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
         NaffException('Wrong number of dimensions for input array.')
 
     if (signal.shape[1]-1) % 6:
-        raise NaffException('Number of points minus 1 must be divisible by 6.')
+        q, r = divmod(signal.shape[1], 6)
+        if r == 0:
+            q -= 1
+        q = 6*q+1
+        signal = signal[:, :q]
 
     freqs = _np.zeros((signal.shape[0], nr_ff))
     real = _np.zeros((signal.shape[0], nr_ff))


### PR DESCRIPTION
With this PR `pyaccel.naff.general_naff` doesn't more require an input signal with the size of the form `6*L-1`, where `L` is an integer.
Now the code automatically discards a minimum quantity of data to satisfy this condition.

I also would like to talk about a bug where the option `is real` of this same function is not working. An example:
```python
T = 10*np.pi # Space length
N = 100 # Number of points
t = np.linspace(0,T,num=N)
f = 0.4 # frequency
y = np.sin(2*np.pi*f*t) # Signal
s_r = N/T # Sample rate

freqs, fourier = pa.naff.naff_general(y, nr_ff=1, is_real=True, window=1)

print(s_r*freqs)
```
output: `-0.4040392872313213`

We get negative frequencies despite `is_real=True`. 

This contradicts the current documentation, which says: ` "In case is_real is true, only positive frequencies in the interval
[0, 0.5] are returned" `.

I tried to search the reason for this, but the naff calculation is performed by `trackcpp` (and with comments and variables in french) and I didn't know yet how to lead with this C package and his connections with `pyaccel.tracking`.

So, in discussions with @fernandohds564, we prefer to change the documentation to agree with the code outputs instead of making an external change in python without certainly knowing the reasons for this behavior on the original implementation. 