### PR TITLE
Improve function generate bunch to correctly handle envelopes without coupling

### DIFF
--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -84,7 +84,15 @@ def generate_bunch(
             6*n_part, dist_type='norm', cutoff=cutoff).reshape(6, -1)
         # The Cholesky decomposition finds a matrix env_chol such that:
         # env_chol @ env_chol.T == envelope
-        env_chol = _np.linalg.cholesky(envelope)
+        try:
+            env_chol = _np.linalg.cholesky(envelope)
+        except _np.linalg.LinAlgError:
+            # In case there is no coupling the envelope matrix is only
+            # positive semi-definite and we must disconsider the vertical
+            # plane for the decomposition algorithm to work:
+            env_chol = _np.zeros((6, 6))
+            idx = _np.ix_([0, 1, 4, 5], [0, 1, 4, 5])
+            env_chol[idx] = _np.linalg.cholesky(envelope[idx])
         # This way we can find bunch througth:
         bunch = env_chol @ znor
         # where one can see that:

--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -93,7 +93,7 @@ def generate_bunch(
             env_chol = _np.zeros((6, 6))
             idx = _np.ix_([0, 1, 4, 5], [0, 1, 4, 5])
             env_chol[idx] = _np.linalg.cholesky(envelope[idx])
-        # This way we can find bunch througth:
+        # This way we can find bunch through:
         bunch = env_chol @ znor
         # where one can see that:
         # np.cov(bunch) == <bunch @ bunch.T> ==


### PR DESCRIPTION
When there is no coupling in the machine, the envelope matrix is only positive semi-definite, because it has zero eigenvalues in the vertical plane.
On the other hand the `numpy` algorithm that computes the [Cholesky decomposition](https://en.wikipedia.org/wiki/Cholesky_decomposition) of a matrix only works with positive definite matrices, which made the algorithm which [draw particles from the Gaussian distribution](https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Drawing_values_from_the_distribution) to crash with a `numpy.linalg.LinalgError`.

This PR solves this issue by removing the vertical plane from the envelope matrix and performing the Cholesky decomposition of the 4x4 matrix containing the Horizontal and Longitudinal planes only.
This approach was preferred over the more general and common approach of adding a small diagonal matrix to the original envelope matrix because generally our envelope matrix contains very small elements, which would make it delicate to choose the intensity of the small matrix to be added.

