### PR TITLE
PYACCEL.ENH: Adds citation file and DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,13 +4,13 @@ authors:
 - family-names: "de Sá"
   given-names: "Fernando Henrique"
  
-- family-names: "Rocha Resende"
+- family-names: "Resende"
   given-names: "Ximenes"
 
-- family-names: "Barbosa Alves"
+- family-names: "Alves"
   given-names: "Murilo"
   
-- family-names: "Pires Vilela"
+- family-names: "Vilela"
   given-names: "Luana Nayara"
 
 title: "Pyaccel. A Python module for beam dynamics tracking and optics calculations in particle accelerators."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "de Sá"
+  given-names: "Fernando Henrique"
+ 
+- family-names: "Rocha Resende"
+  given-names: "Ximenes"
+
+- family-names: "Barbosa Alves"
+  given-names: "Murilo"
+  
+- family-names: "Pires Vilela"
+  given-names: "Luana Nayara"
+
+title: "Pyaccel. A Python module for beam dynamics tracking and optics calculations in particle accelerators."
+version: 3.14.0
+doi: 10.5281/zenodo.6412041
+date-released: 2022-04-04
+url: "https://github.com/lnls-fac/pyaccel"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/33889807.svg)](https://zenodo.org/badge/latestdoi/33889807)
+
 # pyaccel
 Python module for beam dynamics tracking and optics calculations
 


### PR DESCRIPTION
This PR adds a citation file and a DOI link in the README, which will be displayed as shown in the following print:

![image](https://user-images.githubusercontent.com/61889205/161881266-05598ff7-2bf5-4e2b-83d9-f1d3c355d112.png)

Starting from the next release, any citation of this repo generated by Zotero, Zenodo, or other reference API will create a reference with the information present in the CITATION.cff file.