### PR TITLE
OPT.BUG: calc_beamenvelope in transport lines

### DIFF
--- a/pyaccel/optics/beam_envelope.py
+++ b/pyaccel/optics/beam_envelope.py
@@ -499,12 +499,12 @@ def calc_beamenvelope(
     """
     indices = _tracking._process_indices(accelerator, indices)
 
-    rad_stt = accelerator.radiation_on
-    cav_stt = accelerator.cavity_on
-    accelerator.radiation_on = True
-    accelerator.cavity_on = True
-
     if fixed_point is None:
+        rad_stt = accelerator.radiation_on
+        cav_stt = accelerator.cavity_on
+        accelerator.radiation_on = True
+        accelerator.cavity_on = True
+
         fixed_point = _tracking.find_orbit(
             accelerator, energy_offset=energy_offset)
 
@@ -552,8 +552,9 @@ def calc_beamenvelope(
     envelopes += envelopes.transpose(0, 2, 1)
     envelopes /= 2
 
-    accelerator.radiation_on = rad_stt
-    accelerator.cavity_on = cav_stt
+    if fixed_point is None:
+        accelerator.radiation_on = rad_stt
+        accelerator.cavity_on = cav_stt
 
     if not full:
         return envelopes[indices]

--- a/pyaccel/optics/beam_envelope.py
+++ b/pyaccel/optics/beam_envelope.py
@@ -499,7 +499,9 @@ def calc_beamenvelope(
     """
     indices = _tracking._process_indices(accelerator, indices)
 
+    no_fpoint_flag = False
     if fixed_point is None:
+        no_fpoint_flag = True
         rad_stt = accelerator.radiation_on
         cav_stt = accelerator.cavity_on
         accelerator.radiation_on = True
@@ -552,7 +554,7 @@ def calc_beamenvelope(
     envelopes += envelopes.transpose(0, 2, 1)
     envelopes /= 2
 
-    if fixed_point is None:
+    if no_fpoint_flag:
         accelerator.radiation_on = rad_stt
         accelerator.cavity_on = cav_stt
 


### PR DESCRIPTION
The optics.calc_beamenvelope function was always turning on the cavity and the radiation, even if a fixed point is passed.
In this way, an exception occurs when propagating the envelope in a transport line, because its cavity is always False and an immutable property.
I changed the method to only turn on the cavity and rad if the fixed point is not passed.