### PR TITLE
Remove deprecated numpy aliases

### DIFF
--- a/pyaccel/accelerator.py
+++ b/pyaccel/accelerator.py
@@ -275,7 +275,7 @@ class Accelerator(object):
         if isinstance(index, slice):
             start, stop, step = index.indices(len(self))
             index = set(range(start, stop, step))
-        if isinstance(index, (int, _np.int_)):
+        if isinstance(index, int):
             self.trackcpp_acc.lattice.erase(
                 self.trackcpp_acc.lattice.begin() + int(index))
         elif isinstance(index, (set, list, tuple, _np.ndarray)):
@@ -286,7 +286,7 @@ class Accelerator(object):
 
     def __getitem__(self, index):
         """."""
-        if isinstance(index, (int, _np.int_)):
+        if isinstance(index, int):
             ele = _elements.Element()
             ele.trackcpp_e = self.trackcpp_acc.lattice[int(index)]
             return ele
@@ -314,7 +314,7 @@ class Accelerator(object):
 
     def __setitem__(self, index, value):
         """."""
-        if isinstance(index, (int, _np.int_)):
+        if isinstance(index, int):
             index = [index, ]
         elif isinstance(index, (list, tuple, _np.ndarray)):
             pass
@@ -385,7 +385,7 @@ class Accelerator(object):
 
     def __mul__(self, other):
         """."""
-        if isinstance(other, (int, _np.int_)):
+        if isinstance(other, int):
             if other < 0:
                 raise ValueError('cannot multiply by negative integer')
             elif other == 0:

--- a/pyaccel/lattice.py
+++ b/pyaccel/lattice.py
@@ -1078,7 +1078,7 @@ def add_error_multipoles(lattice, indices, r0, main_monom, Bn_norm=None,
             'Length of main_monoms differs from length of indices.')
 
     # Extend the fields, if necessary to the number of elements in indices
-    types = (int, float, _np.int_, _np.float_)
+    types = (int, float)
     if Bn_norm is None or isinstance(Bn_norm[0], types):
         Bn_norm = len(indices) * [Bn_norm]
     if An_norm is None or isinstance(An_norm[0], types):
@@ -1101,7 +1101,7 @@ def add_error_multipoles(lattice, indices, r0, main_monom, Bn_norm=None,
 
 # --- private functions ---
 def _process_args_errors(indices, values):
-    types = (int, _np.int_)
+    types = (int)
     isflat = False
     if isinstance(indices, types):
         indices = [[indices]]
@@ -1109,7 +1109,7 @@ def _process_args_errors(indices, values):
         indices = [[ind] for ind in indices]
         isflat = True
 
-    types = (int, float, _np.int_, _np.float_)
+    types = (int, float)
     if isinstance(values, types):
         values = [len(ind) * [values] for ind in indices]
     if len(values) != len(indices):

--- a/pyaccel/lifetime.py
+++ b/pyaccel/lifetime.py
@@ -313,7 +313,7 @@ class Lifetime:
             spos = self._optics_data.spos
             accp = spos*0.0 + val[1]
             accn = spos*0.0 + val[0]
-        elif isinstance(val, (int, _np.int, float, _np.float)):
+        elif isinstance(val, (int, float)):
             spos = self._optics_data.spos
             accp = spos*0.0 + val
             accn = spos*0.0 - val
@@ -339,7 +339,7 @@ class Lifetime:
                     "Dictionary must contain keys 'spos', 'acc'")
             spos = val['spos']
             acc = val['acc']
-        elif isinstance(val, (int, _np.int, float, _np.float)):
+        elif isinstance(val, (int, float)):
             spos = self._optics_data.spos
             acc = spos*0.0 + val
         else:
@@ -364,7 +364,7 @@ class Lifetime:
                     "Dictionary must contain keys 'spos', 'acc'")
             spos = val['spos']
             acc = val['acc']
-        elif isinstance(val, (int, _np.int, float, _np.float)):
+        elif isinstance(val, (int, float)):
             spos = self._optics_data.spos
             acc = spos*0.0 + val
         else:

--- a/pyaccel/optics/edwards_teng.py
+++ b/pyaccel/optics/edwards_teng.py
@@ -276,7 +276,7 @@ class EdwardsTengArray(_np.ndarray):
     def __new__(cls, edteng=None, copy=True):
         """."""
         length = 1
-        if isinstance(edteng, (int, _np.int)):
+        if isinstance(edteng, int):
             length = edteng
             edteng = None
         elif isinstance(edteng, EdwardsTengArray):

--- a/pyaccel/optics/twiss.py
+++ b/pyaccel/optics/twiss.py
@@ -159,7 +159,7 @@ class TwissArray(_np.ndarray):
     def __new__(cls, twiss=None, copy=True):
         """."""
         length = 1
-        if isinstance(twiss, (int, _np.int)):
+        if isinstance(twiss, int):
             length = twiss
             twiss = None
         elif isinstance(twiss, TwissArray):
@@ -425,7 +425,7 @@ def calc_twiss(
     indices = _tracking._process_indices(accelerator, indices)
 
     _m66 = _trackcpp.Matrix()
-    twiss = _np.zeros((len(accelerator)+1, len(Twiss.ORDER)), dtype=_np.float)
+    twiss = _np.zeros((len(accelerator)+1, len(Twiss.ORDER)), dtype=float)
 
     if init_twiss is not None:
         # as a transport line: uses init_twiss


### PR DESCRIPTION
As of `numpy` v1.20, `numpy.float` as well as similar aliases, including `numpy.int`,  were deprecated. These are simply aliases for the builtin `float` and `int`. `numpy` v1.24.0 has removed these aliases completely, leading to an `AttributeError` whenever they are called. 