### PR TITLE
nullptr workaround for t_in, r_in, t_out and r_out

### DIFF
--- a/pyaccel/elements.py
+++ b/pyaccel/elements.py
@@ -762,6 +762,8 @@ class Element:
         """."""
         Element._check_type(value, Element._t_valid_types)
         Element._check_size(value, _NUM_COORDS)
+        self.trackcpp_e.t_in = Element._allocate_c_array_if_needed(
+            self.trackcpp_e.t_in, _NUM_COORDS)
         Element._set_c_array_from_vector(
             self.trackcpp_e.t_in, _NUM_COORDS, value)
 
@@ -775,6 +777,8 @@ class Element:
         """."""
         Element._check_type(value, Element._t_valid_types)
         Element._check_size(value, _NUM_COORDS)
+        self.trackcpp_e.t_out = Element._allocate_c_array_if_needed(
+            self.trackcpp_e.t_out, _NUM_COORDS)
         Element._set_c_array_from_vector(
             self.trackcpp_e.t_out, _NUM_COORDS, value)
 
@@ -788,6 +792,8 @@ class Element:
         """."""
         Element._check_type(value, Element._r_valid_types)
         Element._check_shape(value, _DIMS)
+        self.trackcpp_e.r_in = Element._allocate_c_array_if_needed(
+            self.trackcpp_e.r_in, int(_DIMS[0]*_DIMS[1]))
         Element._set_c_array_from_matrix(self.trackcpp_e.r_in, _DIMS, value)
 
     @property
@@ -800,6 +806,8 @@ class Element:
         """."""
         Element._check_type(value, Element._r_valid_types)
         Element._check_shape(value, _DIMS)
+        self.trackcpp_e.r_out = Element._allocate_c_array_if_needed(
+            self.trackcpp_e.r_out, int(_DIMS[0]*_DIMS[1]))
         Element._set_c_array_from_matrix(self.trackcpp_e.r_out, _DIMS, value)
 
     def __eq__(self, other):
@@ -891,6 +899,13 @@ class Element:
     # --- private methods ---
 
     @staticmethod
+    def _allocate_c_array_if_needed(array, size):
+        if _trackcpp.check_is_nullptr(array):
+            arr = _trackcpp.c_array_create(size)
+            return arr
+        return array
+
+    @staticmethod
     def _set_c_array_from_vector(array, size, values):
         """."""
         if not size == len(values):
@@ -929,15 +944,21 @@ class Element:
 
     @staticmethod
     def _get_coord_vector(pointer):
-        address = int(pointer)
-        c_array = _COORD_VECTOR.from_address(address)
-        return _numpy.ctypeslib.as_array(c_array)
+        if not _trackcpp.check_is_nullptr(pointer):
+            address = int(pointer)
+            c_array = _COORD_VECTOR.from_address(address)
+            return _numpy.ctypeslib.as_array(c_array)
+        else:
+            return _numpy.zeros(_NUM_COORDS)
 
     @staticmethod
     def _get_coord_matrix(pointer):
-        address = int(pointer)
-        c_array = _COORD_MATRIX.from_address(address)
-        return _numpy.ctypeslib.as_array(c_array)
+        if not _trackcpp.check_is_nullptr(pointer):
+            address = int(pointer)
+            c_array = _COORD_MATRIX.from_address(address)
+            return _numpy.ctypeslib.as_array(c_array)
+        else:
+            return _numpy.identity(_NUM_COORDS)
 
 
 _warnings.filterwarnings(

--- a/pyaccel/elements.py
+++ b/pyaccel/elements.py
@@ -763,7 +763,7 @@ class Element:
         Element._check_type(value, Element._t_valid_types)
         Element._set_c_array_from_vector(
             self.trackcpp_e.t_in, _NUM_COORDS, value)
-        self.trackcpp_e.has_t_in = True
+        self.trackcpp_e.reflag_t_in()
 
     @property
     def t_out(self):
@@ -776,7 +776,7 @@ class Element:
         Element._check_type(value, Element._t_valid_types)
         Element._set_c_array_from_vector(
             self.trackcpp_e.t_out, _NUM_COORDS, value)
-        self.trackcpp_e.has_t_out = True
+        self.trackcpp_e.reflag_t_out()
 
     @property
     def r_in(self):
@@ -789,7 +789,7 @@ class Element:
         Element._check_type(value, Element._r_valid_types)
         Element._set_c_array_from_matrix(
             self.trackcpp_e.r_in, _DIMS, value)
-        self.trackcpp_e.has_r_in = True
+        self.trackcpp_e.reflag_r_in()
 
     @property
     def r_out(self):
@@ -800,10 +800,9 @@ class Element:
     def r_out(self, value):
         """."""
         Element._check_type(value, Element._r_valid_types)
-        Element._check_shape(value, _DIMS)
         Element._set_c_array_from_matrix(
             self.trackcpp_e.r_out, _DIMS, value)
-        self.trackcpp_e.has_r_out = True
+        self.trackcpp_e.reflag_r_out()
 
     def __eq__(self, other):
         """."""
@@ -975,8 +974,8 @@ class TransOrRotArray(_numpy.ndarray):
 
     def __setitem__(self, index, value):
         """."""
-        setattr(self._e, "has_"+self.field, True)
         super().__setitem__(index, value)
+        getattr(self._e, "reflag_"+self.field)()
 
     def is_identity(self):
         """."""
@@ -985,8 +984,7 @@ class TransOrRotArray(_numpy.ndarray):
 
     def reflag(self):
         """."""
-        if self.is_identity():
-            setattr(self._e, "has_"+self.field, False)
+        return getattr(self._e, "reflag_"+self.field)
 
 _warnings.filterwarnings(
     "ignore", "Item size computed from the PEP 3118 \

--- a/pyaccel/elements.py
+++ b/pyaccel/elements.py
@@ -329,10 +329,6 @@ class Element:
             raise TypeError(
                 'element must be a trackcpp.Element or a Element object.')
         self.trackcpp_e = _trackcpp.Element(element)
-        self._t_in = T(self.trackcpp_e, "t_in")
-        self._t_out = T(self.trackcpp_e, "t_out")
-        self._r_in = R(self.trackcpp_e, "r_in")
-        self._r_out = R(self.trackcpp_e, "r_out")
 
     @property
     def fam_name(self):
@@ -760,55 +756,63 @@ class Element:
     @property
     def t_in(self):
         """."""
-        return T(self.trackcpp_e, "t_in")
-        # return Element._get_coord_vector(self.trackcpp_e.t_in)
+        # return T(self.trackcpp_e, "t_in")
+        return Element._get_coord_vector(self.trackcpp_e.t_in)
 
     @t_in.setter
     def t_in(self, value):
         """."""
         Element._check_type(value, Element._t_valid_types)
         Element._check_size(value, _NUM_COORDS)
-        self.t_in[:] = value[:]
+        Element._set_c_array_from_vector(
+            self.trackcpp_e.t_in, _NUM_COORDS, value)
+        # self.t_in[:] = value[:]
 
     @property
     def t_out(self):
         """."""
-        return T(self.trackcpp_e, "t_out")
-        # return Element._get_coord_vector(self.trackcpp_e.t_out)
+        # return T(self.trackcpp_e, "t_out")
+        return Element._get_coord_vector(self.trackcpp_e.t_out)
 
     @t_out.setter
     def t_out(self, value):
         """."""
         Element._check_type(value, Element._t_valid_types)
         Element._check_size(value, _NUM_COORDS)
-        self.t_out[:] = value[:]
+        Element._set_c_array_from_vector(
+            self.trackcpp_e.t_out, _NUM_COORDS, value)
+        # self.t_out[:] = value[:]
 
     @property
     def r_in(self):
         """."""
-        return R(self.trackcpp_e, "r_in")
-        # return Element._get_coord_matrix(self.trackcpp_e.r_in)
+        # return R(self.trackcpp_e, "r_in")
+        return Element._get_coord_matrix(self.trackcpp_e.r_in)
 
     @r_in.setter
     def r_in(self, value):
         """."""
         Element._check_type(value, Element._r_valid_types)
         Element._check_shape(value, _DIMS)
-        self.r_in[:,:] = value[:,:]
+        Element._set_c_array_from_matrix(
+            self.trackcpp_e.r_in, _DIMS, value)
+        # self.r_in[:,:] = value[:,:]
 
     @property
     def r_out(self):
         """."""
-        return R(self.trackcpp_e, "r_out")
-        # return Element._get_coord_matrix(self.trackcpp_e.r_out)
+        # return R(self.trackcpp_e, "r_out")
+        return Element._get_coord_matrix(self.trackcpp_e.r_out)
 
     @r_out.setter
     def r_out(self, value):
         """."""
         Element._check_type(value, Element._r_valid_types)
         Element._check_shape(value, _DIMS)
-        self.r_out[:,:] = value[:,:]
-    
+        Element._set_c_array_from_matrix(
+            self.trackcpp_e.r_out, _DIMS, value)
+        # self.r_out[:,:] = value[:,:]
+
     def __eq__(self, other):
         """."""
         if not isinstance(other, Element):
@@ -954,56 +958,56 @@ class Element:
         return _numpy.ctypeslib.as_array(c_array)
 
 
-class T(_numpy.ndarray):
-    def __new__(cls, c_element, field):
-        obj = _numpy.ndarray.__new__(cls, shape=(6,), dtype=float)
-        t = Element._get_coord_vector(getattr(c_element, field))
-        obj[:] = t[:]
-        obj._t = t
-        obj._e = c_element
-        obj.field = field
-        return obj
+# class T(_numpy.ndarray):
+#     def __new__(cls, c_element, field):
+#         obj = _numpy.ndarray.__new__(cls, shape=(6,), dtype=float)
+#         t = Element._get_coord_vector(getattr(c_element, field))
+#         obj[:] = t[:]
+#         obj._t = t
+#         obj._e = c_element
+#         obj.field = field
+#         return obj
 
-    def __setitem__(self, index, value):
-        """."""
-        if hasattr(self, '_t'):
-            self._t[index] = value
-            setattr(self._e, "has_"+self.field, True)
-        super().__setitem__(index, value)
+#     def __setitem__(self, index, value):
+#         """."""
+#         if hasattr(self, '_t'):
+#             self._t[index] = value
+#             setattr(self._e, "has_"+self.field, True)
+#         super().__setitem__(index, value)
 
-        if self.iszero() and hasattr(self, "_t"):
-            setattr(self._e, "has_"+self.field, False)
+#         if self.iszero() and hasattr(self, "_t"):
+#             setattr(self._e, "has_"+self.field, False)
 
-    def iszero(self):
-        if _numpy.any(self != _numpy.zeros(6, dtype=float)):
-            return False
-        return True
+#     def iszero(self):
+#         if _numpy.any(self != _numpy.zeros(6, dtype=float)):
+#             return False
+#         return True
 
 
-class R(_numpy.ndarray):
-    def __new__(cls, c_element, field):
-        obj = _numpy.ndarray.__new__(cls, shape=(6,6), dtype=float)
-        r = Element._get_coord_matrix(getattr(c_element, field))
-        obj[:,:] = r[:,:]
-        obj._r = r
-        obj._e = c_element
-        obj.field = field
-        return obj
+# class R(_numpy.ndarray):
+#     def __new__(cls, c_element, field):
+#         obj = _numpy.ndarray.__new__(cls, shape=(6,6), dtype=float)
+#         r = Element._get_coord_matrix(getattr(c_element, field))
+#         obj[:,:] = r[:,:]
+#         obj._r = r
+#         obj._e = c_element
+#         obj.field = field
+#         return obj
 
-    def __setitem__(self, index, value):
-        """."""
-        if hasattr(self, '_r'):
-            self._r[index] = value
-            setattr(self._e, "has_"+self.field, True)
-        super().__setitem__(index, value)
+#     def __setitem__(self, index, value):
+#         """."""
+#         if hasattr(self, '_r'):
+#             self._r[index] = value
+#             setattr(self._e, "has_"+self.field, True)
+#         super().__setitem__(index, value)
 
-        if self.isidentity() and hasattr(self, "_r"):
-            setattr(self._e, "has_"+self.field, False)
+#         if self.isidentity() and hasattr(self, "_r"):
+#             setattr(self._e, "has_"+self.field, False)
 
-    def isidentity(self):
-        if _numpy.any(self != _numpy.identity(6, dtype=float)):
-            return False
-        return True
+#     def isidentity(self):
+#         if _numpy.any(self != _numpy.identity(6, dtype=float)):
+#             return False
+#         return True
 
 
 _warnings.filterwarnings(

--- a/pyaccel/elements.py
+++ b/pyaccel/elements.py
@@ -721,22 +721,27 @@ class Element:
     @property
     def polynom_a(self):
         """."""
-        return _Polynom(self.trackcpp_e.polynom_a)
+        return Poly(self.trackcpp_e, "polynom_a")
 
     @polynom_a.setter
     def polynom_a(self, value):
         """."""
-        self.trackcpp_e.polynom_a[:] = value[:]
+        Element._check_type(value, self._t_valid_types)
+        self.trackcpp_e.polynom_a.resize(len(value))
+        self.polynom_a[:] = value[:]
+
 
     @property
     def polynom_b(self):
         """."""
-        return _Polynom(self.trackcpp_e.polynom_b)
+        return Poly(self.trackcpp_e, "polynom_b")
 
     @polynom_b.setter
     def polynom_b(self, value):
         """."""
-        self.trackcpp_e.polynom_b[:] = value[:]
+        Element._check_type(value, self._t_valid_types)
+        self.trackcpp_e.polynom_b.resize(len(value))
+        self.polynom_b[:] = value[:]
 
     @property
     def matrix66(self):
@@ -980,6 +985,18 @@ class TransOrRotArray(_numpy.ndarray):
         """."""
         if self.is_identity():
             setattr(self._e, "has_"+self.field, False)
+
+class Poly(_numpy.ndarray):
+    """."""
+    def __new__(cls, c_element, field):
+        """."""
+        address = int(getattr(c_element, field).my_beautiful_pointer())
+        nullvec = _ctypes.c_double*getattr(c_element, field).size()
+        c_array = nullvec.from_address(address)
+        obj = _numpy.ctypeslib.as_array(c_array).view(cls)
+        obj._e = c_element
+        obj.field = field
+        return obj
 
 _warnings.filterwarnings(
     "ignore", "Item size computed from the PEP 3118 \

--- a/pyaccel/elements.py
+++ b/pyaccel/elements.py
@@ -7,7 +7,7 @@ import numpy as _numpy
 
 import trackcpp as _trackcpp
 
-from .utils import interactive as _interactive, Polynom as _Polynom
+from .utils import interactive as _interactive
 
 
 _DBL_MAX = _trackcpp.get_double_max()
@@ -721,27 +721,22 @@ class Element:
     @property
     def polynom_a(self):
         """."""
-        return Poly(self.trackcpp_e, "polynom_a")
+        return Element._get_cpp_vector(self.trackcpp_e.polynom_a)
 
     @polynom_a.setter
     def polynom_a(self, value):
         """."""
-        Element._check_type(value, self._t_valid_types)
-        self.trackcpp_e.polynom_a.resize(len(value))
-        self.polynom_a[:] = value[:]
-
+        self.trackcpp_e.polynom_a[:] = value
 
     @property
     def polynom_b(self):
         """."""
-        return Poly(self.trackcpp_e, "polynom_b")
+        return Element._get_cpp_vector(self.trackcpp_e.polynom_b)
 
     @polynom_b.setter
     def polynom_b(self, value):
         """."""
-        Element._check_type(value, self._t_valid_types)
-        self.trackcpp_e.polynom_b.resize(len(value))
-        self.polynom_b[:] = value[:]
+        self.trackcpp_e.polynom_b[:] = value
 
     @property
     def matrix66(self):
@@ -954,6 +949,13 @@ class Element:
         c_array = _COORD_MATRIX.from_address(address)
         return _numpy.ctypeslib.as_array(c_array)
 
+    @staticmethod
+    def _get_cpp_vector(cppvector):
+        address = int(cppvector.data_())
+        nullvec = _ctypes.c_double*cppvector.size()
+        c_array = nullvec.from_address(address)
+        return _numpy.ctypeslib.as_array(c_array)
+
 
 class TransOrRotArray(_numpy.ndarray):
     """."""
@@ -985,18 +987,6 @@ class TransOrRotArray(_numpy.ndarray):
         """."""
         if self.is_identity():
             setattr(self._e, "has_"+self.field, False)
-
-class Poly(_numpy.ndarray):
-    """."""
-    def __new__(cls, c_element, field):
-        """."""
-        address = int(getattr(c_element, field).my_beautiful_pointer())
-        nullvec = _ctypes.c_double*getattr(c_element, field).size()
-        c_array = nullvec.from_address(address)
-        obj = _numpy.ctypeslib.as_array(c_array).view(cls)
-        obj._e = c_element
-        obj.field = field
-        return obj
 
 _warnings.filterwarnings(
     "ignore", "Item size computed from the PEP 3118 \

--- a/pyaccel/lattice.py
+++ b/pyaccel/lattice.py
@@ -522,8 +522,6 @@ def set_error_misalignment_x(lattice, indices, values):
             lattice[idx].t_in[0] = yaw - val
             lattice[idx].t_out[0] = yaw + val
 
-    _reflag_translation_vectors(lattice, indices)
-
 
 @_interactive
 def add_error_misalignment_x(lattice, indices, values):
@@ -549,8 +547,6 @@ def add_error_misalignment_x(lattice, indices, values):
         for idx, val in zip(segs, vals):
             lattice[idx].t_in[0] += -val
             lattice[idx].t_out[0] += val
-
-    _reflag_translation_vectors(lattice, indices)
 
 
 @_interactive
@@ -609,8 +605,6 @@ def set_error_misalignment_y(lattice, indices, values):
             lattice[idx].t_in[2] = pitch - val
             lattice[idx].t_out[2] = pitch + val
 
-    _reflag_translation_vectors(lattice, indices)
-
 
 @_interactive
 def add_error_misalignment_y(lattice, indices, values):
@@ -637,7 +631,7 @@ def add_error_misalignment_y(lattice, indices, values):
             lattice[idx].t_in[2] += -val
             lattice[idx].t_out[2] += val
 
-    _reflag_translation_vectors(lattice, indices)
+
 
 
 @_interactive
@@ -709,7 +703,6 @@ def set_error_rotation_roll(lattice, indices, values):
                 ele.r_in = rot
                 ele.r_out = rot.T
 
-    _reflag_rotation_matrices(lattice, indices)
 
 
 @_interactive
@@ -752,7 +745,6 @@ def add_error_rotation_roll(lattice, indices, values):
                 ele.r_in = _np.dot(rot, ele.r_in)
                 ele.r_out = _np.dot(ele.r_out, rot.T)
 
-    _reflag_rotation_matrices(lattice, indices)
 
 
 @_interactive
@@ -822,7 +814,6 @@ def set_error_rotation_pitch(lattice, indices, values):
         lattice[segs[-1]].t_out[3] = -angy
         lattice[segs[-1]].t_out[5] = path
 
-    _reflag_translation_vectors(lattice, indices)
 
 
 @_interactive
@@ -859,7 +850,6 @@ def add_error_rotation_pitch(lattice, indices, values):
         lattice[segs[-1]].t_out += _np.array(
             [0, 0, -(L/2)*angy, -angy, 0, path])
 
-    _reflag_translation_vectors(lattice, indices)
 
 @_interactive
 def get_error_rotation_yaw(lattice, indices):
@@ -927,7 +917,6 @@ def set_error_rotation_yaw(lattice, indices, values):
         lattice[segs[-1]].t_out[1] = -angx
         lattice[segs[-1]].t_out[5] = path
 
-    _reflag_translation_vectors(lattice, indices)
 
 @_interactive
 def add_error_rotation_yaw(lattice, indices, values):
@@ -963,7 +952,6 @@ def add_error_rotation_yaw(lattice, indices, values):
         lattice[segs[-1]].t_out += _np.array(
             [-(L/2)*angx, -angx, 0, 0, 0, path])
 
-    _reflag_translation_vectors(lattice, indices)
 
 
 @_interactive
@@ -1199,30 +1187,3 @@ def _is_equal_val1_iterable(val1, val2):
     except TypeError:
         # 'val1' is iterable but 'val2' is not
         return False
-
-
-def _reflag_translation_vectors(lattice, indices):
-    _zeros = _np.zeros(6, dtype=float)
-    for i in _np.array(indices).ravel():
-        elem = lattice[i]
-        if _np.any(elem.t_in != _zeros):
-            elem.trackcpp_e.has_t_in = True
-        else:
-            elem.trackcpp_e.has_t_in = False
-        if _np.any(elem.t_out != _zeros):
-            elem.trackcpp_e.has_t_out = True
-        else:
-            elem.trackcpp_e.has_t_out = False
-
-def _reflag_rotation_matrices(lattice, indices):
-    _identity6 = _np.identity(6, dtype=float)
-    for i in _np.array(indices).ravel():
-        elem = lattice[i]
-        if _np.any(elem.r_in != _identity6):
-            elem.trackcpp_e.has_r_in = True
-        else:
-            elem.trackcpp_e.has_r_in = False
-        if _np.any(elem.r_out != _identity6):
-            elem.trackcpp_e.has_r_out = True
-        else:
-            elem.trackcpp_e.has_r_out = False

--- a/pyaccel/lattice.py
+++ b/pyaccel/lattice.py
@@ -522,6 +522,8 @@ def set_error_misalignment_x(lattice, indices, values):
             lattice[idx].t_in[0] = yaw - val
             lattice[idx].t_out[0] = yaw + val
 
+    _reflag_translation_vectors(lattice, indices)
+
 
 @_interactive
 def add_error_misalignment_x(lattice, indices, values):
@@ -547,6 +549,8 @@ def add_error_misalignment_x(lattice, indices, values):
         for idx, val in zip(segs, vals):
             lattice[idx].t_in[0] += -val
             lattice[idx].t_out[0] += val
+
+    _reflag_translation_vectors(lattice, indices)
 
 
 @_interactive
@@ -605,6 +609,8 @@ def set_error_misalignment_y(lattice, indices, values):
             lattice[idx].t_in[2] = pitch - val
             lattice[idx].t_out[2] = pitch + val
 
+    _reflag_translation_vectors(lattice, indices)
+
 
 @_interactive
 def add_error_misalignment_y(lattice, indices, values):
@@ -630,6 +636,8 @@ def add_error_misalignment_y(lattice, indices, values):
         for idx, val in zip(segs, vals):
             lattice[idx].t_in[2] += -val
             lattice[idx].t_out[2] += val
+
+    _reflag_translation_vectors(lattice, indices)
 
 
 @_interactive
@@ -701,6 +709,8 @@ def set_error_rotation_roll(lattice, indices, values):
                 ele.r_in = rot
                 ele.r_out = rot.T
 
+    _reflag_rotation_matrices(lattice, indices)
+
 
 @_interactive
 def add_error_rotation_roll(lattice, indices, values):
@@ -741,6 +751,8 @@ def add_error_rotation_roll(lattice, indices, values):
             else:
                 ele.r_in = _np.dot(rot, ele.r_in)
                 ele.r_out = _np.dot(ele.r_out, rot.T)
+
+    _reflag_rotation_matrices(lattice, indices)
 
 
 @_interactive
@@ -810,6 +822,8 @@ def set_error_rotation_pitch(lattice, indices, values):
         lattice[segs[-1]].t_out[3] = -angy
         lattice[segs[-1]].t_out[5] = path
 
+    _reflag_translation_vectors(lattice, indices)
+
 
 @_interactive
 def add_error_rotation_pitch(lattice, indices, values):
@@ -845,6 +859,7 @@ def add_error_rotation_pitch(lattice, indices, values):
         lattice[segs[-1]].t_out += _np.array(
             [0, 0, -(L/2)*angy, -angy, 0, path])
 
+    _reflag_translation_vectors(lattice, indices)
 
 @_interactive
 def get_error_rotation_yaw(lattice, indices):
@@ -912,6 +927,7 @@ def set_error_rotation_yaw(lattice, indices, values):
         lattice[segs[-1]].t_out[1] = -angx
         lattice[segs[-1]].t_out[5] = path
 
+    _reflag_translation_vectors(lattice, indices)
 
 @_interactive
 def add_error_rotation_yaw(lattice, indices, values):
@@ -946,6 +962,8 @@ def add_error_rotation_yaw(lattice, indices, values):
         lattice[segs[0]].t_in += _np.array([-(L/2)*angx, angx, 0, 0, 0, 0])
         lattice[segs[-1]].t_out += _np.array(
             [-(L/2)*angx, -angx, 0, 0, 0, path])
+
+    _reflag_translation_vectors(lattice, indices)
 
 
 @_interactive
@@ -1181,3 +1199,30 @@ def _is_equal_val1_iterable(val1, val2):
     except TypeError:
         # 'val1' is iterable but 'val2' is not
         return False
+
+
+def _reflag_translation_vectors(lattice, indices):
+    _zeros = _np.zeros(6, dtype=float)
+    for i in _np.array(indices).ravel():
+        elem = lattice[i]
+        if _np.any(elem.t_in != _zeros):
+            elem.trackcpp_e.has_t_in = True
+        else:
+            elem.trackcpp_e.has_t_in = False
+        if _np.any(elem.t_out != _zeros):
+            elem.trackcpp_e.has_t_out = True
+        else:
+            elem.trackcpp_e.has_t_out = False
+
+def _reflag_rotation_matrices(lattice, indices):
+    _identity6 = _np.identity(6, dtype=float)
+    for i in _np.array(indices).ravel():
+        elem = lattice[i]
+        if _np.any(elem.r_in != _identity6):
+            elem.trackcpp_e.has_r_in = True
+        else:
+            elem.trackcpp_e.has_r_in = False
+        if _np.any(elem.r_out != _identity6):
+            elem.trackcpp_e.has_r_out = True
+        else:
+            elem.trackcpp_e.has_r_out = False

--- a/pyaccel/utils.py
+++ b/pyaccel/utils.py
@@ -57,34 +57,6 @@ def deprecated(function):
     return new_function
 
 
-class Polynom(_numpy.ndarray):
-    """."""
-
-    def __new__(cls, polynom):
-        """."""
-        shape = (len(polynom),)
-        array = _numpy.ndarray.__new__(cls, shape=shape)
-        array[:] = polynom[:]
-        array._polynom = polynom
-        return array
-
-    def __setitem__(self, index, value):
-        """."""
-        if hasattr(self, '_polynom'):
-            self._polynom[index] = value
-        super().__setitem__(index, value)
-
-    def __eq__(self, other):
-        """."""
-        if not isinstance(other, Polynom):
-            return NotImplemented
-        if len(self) != len(other):
-            return False
-        if (self != other).any():
-            return False
-        return True
-
-
 @interactive
 def set_random_seed(rnd_seed : int):
     """Set random number seed used in trackcpp."""


### PR DESCRIPTION
Copy from lnls-fac/trackcpp#69 : 
"The latest studies with the development of Track.jl showed that the functions of translating and rotating the particle's referential in the tracking with local2global and global2local can slow down the simulations even if the translation vectors are zero or the rotation matrices are the identity. To enhance it, the elements properties `t_in`, `t_out`, `r_in` and `r_out` will be set as nullptr by default. This way, the referential changes will check if the vectors/matrices are null and skip the translation and/or rotation."

To make pyaccel consistent with the changes in lnls-fac/trackcpp#69 (trackcpp: local2global-improvements), this PR modifies the setters of the element's properties `t_in`, `t_out`, `r_in` and `r_out`.