### PR TITLE
Import trackcpp's vector<string> as python tuples

### DIFF
--- a/pyaccel/accelerator.py
+++ b/pyaccel/accelerator.py
@@ -7,7 +7,7 @@ import trackcpp as _trackcpp
 
 from . import elements as _elements
 from .utils import interactive as _interactive
-from .utils import RADIATION_STATES_NAMES as _RADIATION_STATES_NAMES
+from .utils import RADIATION_STATES as _RADIATION_STATES
 
 
 class AcceleratorException(Exception):
@@ -147,7 +147,7 @@ class Accelerator(object):
     @property
     def radiation_on_str(self):
         """Return radiation_on state in string format."""
-        return _RADIATION_STATES_NAMES[self.trackcpp_acc.radiation_on]
+        return _RADIATION_STATES[self.trackcpp_acc.radiation_on]
 
     @radiation_on.setter
     def radiation_on(self, value):
@@ -163,18 +163,18 @@ class Accelerator(object):
         Raises:
             ValueError
         """
-        nr_states = len(_RADIATION_STATES_NAMES)
+        nr_states = len(_RADIATION_STATES)
         if isinstance(value, (int, bool, float)) and \
                 0 <= value <= nr_states:
             self.trackcpp_acc.radiation_on = int(value)
-        elif isinstance(value, str) and value in _RADIATION_STATES_NAMES:
+        elif isinstance(value, str) and value in _RADIATION_STATES:
             self.trackcpp_acc.radiation_on = \
-                _RADIATION_STATES_NAMES.index(value)
+                _RADIATION_STATES.index(value)
         else:
             errtxt = (
                 'Value not valid, radiation_on must be '
                 f'0 < int < {nr_states} or one of'
-                f'the strings: {_RADIATION_STATES_NAMES}'
+                f'the strings: {_RADIATION_STATES}'
                 )
             raise ValueError(errtxt)
 

--- a/pyaccel/elements.py
+++ b/pyaccel/elements.py
@@ -14,7 +14,7 @@ _DBL_MAX = _trackcpp.get_double_max()
 _NUM_COORDS = 6
 _DIMS = (_NUM_COORDS, _NUM_COORDS)
 
-PASS_METHODS = _trackcpp.pm_dict
+PASS_METHODS  = tuple(_trackcpp.pm_dict)
 VChamberShape = _trackcpp.VChamberShape
 
 

--- a/pyaccel/utils.py
+++ b/pyaccel/utils.py
@@ -9,22 +9,9 @@ from mathphys.functions import get_namedtuple as _get_namedtuple
 
 INTERACTIVE_LIST = []
 
-# Distributions = _trackcpp.distributions_dict
-DISTRIBUTIONS_NAMES = _trackcpp.distributions_dict
-_states_str = tuple(state.upper() for state in _trackcpp.distributions_dict)
-_indices = (idx for idx in range(len(_states_str)))
-DISTRIBUTIONS_NAMES = _get_namedtuple('DISTRIBUTIONS_NAMES',
-    _states_str, _indices)
-del(_states_str)
-del(_indices)
+DISTRIBUTIONS_NAMES = tuple(_trackcpp.distributions_dict)
 
-
-RADIATION_STATES_NAMES = _trackcpp.rad_dict
-_states_str = tuple(state.upper() for state in _trackcpp.rad_dict)
-_indices = (idx for idx in range(len(_states_str)))
-RADIATION_STATES = _get_namedtuple('RADIATION_STATES', _states_str, _indices)
-del(_states_str)
-del(_indices)
+RADIATION_STATES = tuple(_trackcpp.rad_dict)
 
 
 def interactive(obj):
@@ -86,8 +73,6 @@ def set_distribution(distribution):
     elif isinstance(dist, str) and (dist in DISTRIBUTIONS_NAMES):
         _trackcpp.set_random_distribution(DISTRIBUTIONS_NAMES.index(dist))
     else:
-        errstr = (
-            'The distribution must be one of the options: '
-            f'{DISTRIBUTIONS_NAMES}',
-            )
+        errstr = 'The distribution must be one of the options: ' + \
+            f"{DISTRIBUTIONS_NAMES}"
         raise ValueError(errstr)


### PR DESCRIPTION
This changes avoid a `swig` "bug" that depends on the swig version and differ from machine to machine.

The bug is: depending on the machine and/or the swig version, the exported cpp string vector don't bring the classmethod `index` (Example: the imported `rad_dict` from trackcpp is a vector of the radiation names strings, with this bug, the call `rad_dict.index("bnd_mpole_symplectic4_pass")` may fail.