### PR TITLE
DEL: radiation state manipulation in find_orbit6

### DIFF
--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -619,10 +619,6 @@ def find_orbit6(accelerator, indices=None, fixed_point_guess=None):
     """
     indices = _process_indices(accelerator, indices)
 
-    # The orbit can't be found when quantum excitation is on.
-    rad_stt = accelerator.radiation_on
-    accelerator.radiation_on = 'damping'
-
     if fixed_point_guess is None:
         fixed_point_guess = _trackcpp.CppDoublePos()
     else:
@@ -632,8 +628,6 @@ def find_orbit6(accelerator, indices=None, fixed_point_guess=None):
 
     ret = _trackcpp.track_findorbit6(
         accelerator.trackcpp_acc, _closed_orbit, fixed_point_guess)
-
-    accelerator.radiation_on = rad_stt
 
     if ret > 0:
         raise TrackingException(_trackcpp.string_error_messages[ret])


### PR DESCRIPTION
The present changes fix accelerator's radiation state manipulation in `find_orbit6`. 

The initial implementation was made to prevent the use of `find_orbit6` with accelerators with quantum excitation by changing the radiation state to "damping" temporarily. But the `trackcpp` already manage the radiation state in case of quantum excitation. 

Also, this manipulation turns the radiation state to damping even when the accelerator's radiation state is off.