### PR TITLE
Dev/tracking/feature/return lost pos

### DIFF
--- a/pyaccel/accelerator.py
+++ b/pyaccel/accelerator.py
@@ -9,7 +9,7 @@ from . import elements as _elements
 from .utils import interactive as _interactive
 
 
-class AcceleratorException(Exception):
+class AcceleratorError(Exception):
     """."""
 
 
@@ -126,7 +126,7 @@ class Accelerator(object):
     def harmonic_number(self, value):
         """Set accelerator harmonic number."""
         if not isinstance(value, int) or value < 1:
-            raise AcceleratorException(
+            raise AcceleratorError(
                 'harmonic number has to be a positive integer')
         self.trackcpp_acc.harmonic_number = value
 
@@ -139,7 +139,7 @@ class Accelerator(object):
     def cavity_on(self, value):
         """Set cavity on state."""
         if self.trackcpp_acc.harmonic_number < 1:
-            raise AcceleratorException('invalid harmonic number')
+            raise AcceleratorError('invalid harmonic number')
         self.trackcpp_acc.cavity_on = value
 
     @property
@@ -266,7 +266,7 @@ class Accelerator(object):
     def __setattr__(self, key, value):
         """."""
         if self.__isfrozen and not hasattr(self, key):
-            raise AcceleratorException("%r is a frozen class" % self)
+            raise AcceleratorError("%r is a frozen class" % self)
         object.__setattr__(self, key, value)
 
     def __delitem__(self, index):

--- a/pyaccel/accelerator.py
+++ b/pyaccel/accelerator.py
@@ -1,13 +1,12 @@
 """Accelerator class."""
 
-import numpy as _np
-
 import mathphys as _mp
+import numpy as _np
 import trackcpp as _trackcpp
+from mathphys.functions import get_namedtuple as _get_namedtuple
 
 from . import elements as _elements
 from .utils import interactive as _interactive
-from .utils import RADIATION_STATES_NAMES as _RADIATION_STATES_NAMES
 
 
 class AcceleratorException(Exception):
@@ -17,6 +16,10 @@ class AcceleratorException(Exception):
 @_interactive
 class Accelerator(object):
     """."""
+
+    _states_str = tuple(state.title() for state in _trackcpp.rad_dict)
+    RadiationStates = _get_namedtuple('RadiationStates', _states_str)
+    del _states_str
 
     __isfrozen = False  # this is used to prevent creation of new attributes
 
@@ -147,36 +150,32 @@ class Accelerator(object):
     @property
     def radiation_on_str(self):
         """Return radiation_on state in string format."""
-        return _RADIATION_STATES_NAMES[self.trackcpp_acc.radiation_on]
+        return self.RadiationStates._fields[self.trackcpp_acc.radiation_on]
 
     @radiation_on.setter
     def radiation_on(self, value):
         """Set radiation on state.
 
         Args:
-            value (int, bool or string): Radiation state to be set,
-            the options are:
-            - 0, False, "off"    = No radiative effects.
-            - 1, True, "damping" = Turns on radiation damping, without
-                quantum excitation.
-            - 2, "full" = Turns on radiation damping with quantum excitation
+            value (int, bool or string): Radiation state to be set, the
+                options are:
+                    - 0, False, "Off"    = No radiative effects.
+                    - 1, True, "Damping" = Turns on radiation damping, without
+                        quantum excitation.
+                    - 2, "Full" = Turns on radiation damping with quantum
+                        excitation
+
         Raises:
-            ValueError
+            ValueError: for wrong values in `value` input.
         """
-        nr_states = len(_RADIATION_STATES_NAMES)
-        if isinstance(value, (int, bool, float)) and \
-                0 <= value <= nr_states:
+        radstts = self.RadiationStates
+        if isinstance(value, (int, bool, float)) and int(value) in radstts:
             self.trackcpp_acc.radiation_on = int(value)
-        elif isinstance(value, str) and value in _RADIATION_STATES_NAMES:
+        elif isinstance(value, str) and value.title() in radstts._fields:
             self.trackcpp_acc.radiation_on = \
-                _RADIATION_STATES_NAMES.index(value)
+                radstts._fields.index(value.title())
         else:
-            errtxt = (
-                'Value not valid, radiation_on must be '
-                f'0 < int < {nr_states} or one of'
-                f'the strings: {_RADIATION_STATES_NAMES}'
-                )
-            raise ValueError(errtxt)
+            raise ValueError('Value not valid.')
 
     @property
     def vchamber_on(self):

--- a/pyaccel/naff.py
+++ b/pyaccel/naff.py
@@ -14,7 +14,7 @@ import trackcpp as _trackcpp
 from .utils import interactive as _interactive
 
 
-class NaffException(Exception):
+class NaffError(Exception):
     """."""
 
 
@@ -44,7 +44,7 @@ def naff_general(signal, is_real=True, nr_ff=2, window=1):
         signal = signal[None, :]
 
     if signal.ndim > 2:
-        NaffException('Wrong number of dimensions for input array.')
+        NaffError('Wrong number of dimensions for input array.')
 
     if (signal.shape[1]-1) % 6:
         q, r = divmod(signal.shape[1], 6)

--- a/pyaccel/optics/__init__.py
+++ b/pyaccel/optics/__init__.py
@@ -1,13 +1,13 @@
 """Optics subpackage."""
 
-from .acceptances import calc_transverse_acceptance, \
-    calc_touschek_energy_acceptance
-from .edwards_teng import EdwardsTeng, EdwardsTengArray, calc_edwards_teng, \
+from .acceptances import calc_touschek_energy_acceptance, \
+    calc_transverse_acceptance
+from .beam_envelope import calc_beamenvelope, EqParamsFromBeamEnvelope
+from .edwards_teng import calc_edwards_teng, EdwardsTeng, EdwardsTengArray, \
     estimate_coupling_parameters
-from .miscellaneous import get_chromaticities, get_mcf, get_frac_tunes, \
-    get_curlyh, get_revolution_frequency, get_rf_frequency, get_rf_voltage, \
-    get_revolution_period, OpticsException
-from .eq_params import EqParamsXYModes, EqParamsNormalModes
+from .eq_params import EqParamsNormalModes, EqParamsXYModes
+from .miscellaneous import get_chromaticities, get_curlyh, get_frac_tunes, \
+    get_mcf, get_revolution_frequency, get_revolution_period, \
+    get_rf_frequency, get_rf_voltage, OpticsError
 from .rad_integrals import EqParamsFromRadIntegrals
-from .beam_envelope import EqParamsFromBeamEnvelope, calc_beamenvelope
-from .twiss import Twiss, TwissArray, calc_twiss
+from .twiss import calc_twiss, Twiss, TwissArray

--- a/pyaccel/optics/acceptances.py
+++ b/pyaccel/optics/acceptances.py
@@ -2,13 +2,11 @@
 
 import numpy as _np
 
-from .. import tracking as _tracking
-from .. import lattice as _lattice
+from .. import lattice as _lattice, tracking as _tracking
 from ..utils import interactive as _interactive
-
+from .miscellaneous import get_curlyh as _get_curlyh, \
+    OpticsError as _OpticsError
 from .twiss import calc_twiss as _calc_twiss
-from .miscellaneous import OpticsException as _OpticsException, \
-    get_curlyh as _get_curlyh
 
 
 @_interactive
@@ -24,7 +22,7 @@ def calc_transverse_acceptance(
     n_twi = len(twiss)
     n_acc = len(accelerator)
     if n_twi not in {n_acc, n_acc+1}:
-        raise _OpticsException(
+        raise _OpticsError(
             'Mismatch between size of accelerator and size of twiss object')
 
     betax = twiss.betax
@@ -189,7 +187,7 @@ def _calc_phys_apert_for_touschek(
             twi, *_ = _calc_twiss(
                 accelerator, energy_offset=delta, indices='closed')
             if _np.any(_np.isnan(twi[0].betax)):
-                raise _OpticsException('error')
+                raise _OpticsError('error')
             tune[0, idx] = twi[-1].mux / (2*_np.pi)
             tune[1, idx] = twi[-1].muy / (2*_np.pi)
             beta[idx] = twi[0].betax
@@ -202,7 +200,7 @@ def _calc_phys_apert_for_touschek(
 
             apper_loc = _np.minimum((hmax - rx)**2, (hmin + rx)**2)
             ap_phys[idx] = _np.min(apper_loc / betax)
-    except (_OpticsException, _tracking.TrackingException):
+    except (_OpticsError, _tracking.TrackingError):
         pass
     return curh, ap_phys, tune, beta
 
@@ -218,7 +216,7 @@ def _calc_dyn_apert_for_touschek(
         for idx, en in enumerate(energies):
             rin[:4, idx, :] = _tracking.find_orbit4(
                 accelerator, energy_offset=en).ravel()[:, None]
-    except _tracking.TrackingException:
+    except _tracking.TrackingError:
         pass
     rin = rin.reshape(6, -1)
 

--- a/pyaccel/optics/edwards_teng.py
+++ b/pyaccel/optics/edwards_teng.py
@@ -1,5 +1,4 @@
-"""
-This module to performs linear analysis of coupled lattices.
+"""This module to performs linear analysis of coupled lattices.
 
 Notation is the same as in reference [3]
 In case some strange results appear in phase advances or beta functions,
@@ -19,14 +18,11 @@ References:
 """
 
 import numpy as _np
-
 from mathphys.functions import get_namedtuple as _get_namedtuple
 
-from .. import lattice as _lattice
-from .. import tracking as _tracking
+from .. import lattice as _lattice, tracking as _tracking
 from ..utils import interactive as _interactive
-
-from .miscellaneous import OpticsException as _OpticsException
+from .miscellaneous import OpticsError as _OpticsError
 
 
 class EdwardsTeng(_np.record):
@@ -610,10 +606,10 @@ class EdwardsTengArray(_np.ndarray):
         if isinstance(edteng_list, (list, tuple)):
             for val in edteng_list:
                 if not isinstance(val, (EdwardsTeng, EdwardsTengArray)):
-                    raise _OpticsException(
+                    raise _OpticsError(
                         'can only compose lists of Twiss objects.')
         else:
-            raise _OpticsException('can only compose lists of Twiss objects.')
+            raise _OpticsError('can only compose lists of Twiss objects.')
 
         arrs = list()
         for val in edteng_list:
@@ -680,7 +676,7 @@ def calc_edwards_teng(
             # Turn cavity and radiation states back to their original values.
             accelerator.cavity_on = cav_stt
             accelerator.radiation_on = rad_stt
-            raise _OpticsException(
+            raise _OpticsError(
                 'energy_offset and init_teng are mutually '
                 'exclusive options. Add the desired energy deviation to the '
                 'appropriate position of init_edteng object.')
@@ -692,7 +688,7 @@ def calc_edwards_teng(
             # Turn cavity and radiation states back to their original values.
             accelerator.cavity_on = cav_stt
             accelerator.radiation_on = rad_stt
-            raise _OpticsException(
+            raise _OpticsError(
                 'Either harmonic number was not set or calc_edwards_teng was '
                 'invoked for transport line without initial  EdwardsTeng')
         cod = _tracking.find_orbit(

--- a/pyaccel/optics/miscellaneous.py
+++ b/pyaccel/optics/miscellaneous.py
@@ -1,14 +1,13 @@
 """Optics module."""
 
-import numpy as _np
-
 import mathphys as _mp
+import numpy as _np
 
 from .. import tracking as _tracking
 from ..utils import interactive as _interactive
 
 
-class OpticsException(Exception):
+class OpticsError(Exception):
     """."""
 
 
@@ -18,7 +17,7 @@ def get_rf_frequency(accelerator):
     for e in accelerator:
         if e.frequency != 0.0:
             return e.frequency
-    raise OpticsException('no cavity element in the lattice')
+    raise OpticsError('no cavity element in the lattice')
 
 
 @_interactive
@@ -34,7 +33,7 @@ def get_rf_voltage(accelerator):
         else:
             return voltages
     else:
-        raise OpticsException('no cavity element in the lattice')
+        raise OpticsError('no cavity element in the lattice')
 
 
 @_interactive
@@ -50,7 +49,14 @@ def calc_syncphase(overvoltage):
 
 
 @_interactive
-def calc_rf_acceptance(energy, energy_offset, harmonic_number, rf_voltage, overvoltage, etac):
+def calc_rf_acceptance(
+    energy,
+    energy_offset,
+    harmonic_number,
+    rf_voltage,
+    overvoltage,
+    etac
+):
     """."""
     E0 = energy * (1 + energy_offset)
     V = rf_voltage
@@ -77,11 +83,11 @@ def get_frac_tunes(
     if m1turn is None:
         if dim == '4D':
             m1turn = _tracking.find_m44(
-                accelerator, indices='m44', energy_offset=energy_offset,
+                accelerator, indices=None, energy_offset=energy_offset,
                 fixed_point=fixed_point)
         elif dim == '6D':
             m1turn = _tracking.find_m66(
-                accelerator, indices='m66', fixed_point=fixed_point)
+                accelerator, indices=None, fixed_point=fixed_point)
         else:
             raise Exception('Set valid dimension: 4D or 6D')
 

--- a/pyaccel/optics/twiss.py
+++ b/pyaccel/optics/twiss.py
@@ -476,6 +476,6 @@ def calc_twiss(
         raise _OpticsError(_trackcpp.string_error_messages[r])
 
     twiss = TwissArray(twiss, copy=False)
-    m66 = _tracking._CppMatrix2Numpy(_m66)
+    m66 = _np.array(_m66)
 
     return twiss[indices], m66

--- a/pyaccel/optics/twiss.py
+++ b/pyaccel/optics/twiss.py
@@ -1,14 +1,12 @@
 """Twiss Module."""
 
-import numpy as _np
-
 import mathphys as _mp
+import numpy as _np
 import trackcpp as _trackcpp
 
 from .. import tracking as _tracking
 from ..utils import interactive as _interactive
-
-from .miscellaneous import OpticsException as _OpticsException
+from .miscellaneous import OpticsError as _OpticsError
 
 
 class Twiss(_np.record):
@@ -383,10 +381,10 @@ class TwissArray(_np.ndarray):
         if isinstance(twiss_list, (list, tuple)):
             for val in twiss_list:
                 if not isinstance(val, (Twiss, TwissArray)):
-                    raise _OpticsException(
+                    raise _OpticsError(
                         'can only compose lists of Twiss objects.')
         else:
-            raise _OpticsException('can only compose lists of Twiss objects.')
+            raise _OpticsError('can only compose lists of Twiss objects.')
 
         arrs = list()
         for val in twiss_list:
@@ -413,8 +411,8 @@ def calc_twiss(
             (used only for periodic solutions). Defaults to None.
 
     Raises:
-        pyaccel.tracking.TrackingException: When find_orbit fails to converge.
-        pyaccel.optics.OpticsException: When trackcpp.calc_twiss fails, or
+        pyaccel.tracking.TrackingError: When find_orbit fails to converge.
+        pyaccel.optics.OpticsError: When trackcpp.calc_twiss fails, or
             when accelerator is not configured properly.
 
     Returns:
@@ -433,12 +431,12 @@ def calc_twiss(
         if fixed_point is None:
             _fixed_point = _init_twiss.co
         else:
-            raise _OpticsException(
+            raise _OpticsError(
                 'arguments init_twiss and fixed_point are mutually exclusive')
     else:
         # as a periodic system: try to find periodic solution
         if accelerator.harmonic_number == 0:
-            raise _OpticsException(
+            raise _OpticsError(
                 'Either harmonic number was not set or calc_twiss was'
                 'invoked for transport line without initial twiss')
 
@@ -453,7 +451,7 @@ def calc_twiss(
                     accelerator.trackcpp_acc, _closed_orbit,
                     _fixed_point_guess)
             elif not accelerator.cavity_on and accelerator.radiation_on:
-                raise _OpticsException(
+                raise _OpticsError(
                     'The radiation is on but the cavity is off')
             else:
                 r = _trackcpp.track_findorbit6(
@@ -461,7 +459,7 @@ def calc_twiss(
                     _fixed_point_guess)
 
             if r > 0:
-                raise _tracking.TrackingException(
+                raise _tracking.TrackingError(
                     _trackcpp.string_error_messages[r])
             _fixed_point = _closed_orbit[0]
 
@@ -475,7 +473,7 @@ def calc_twiss(
     r = _trackcpp.calc_twiss_wrapper(
         accelerator.trackcpp_acc, _fixed_point, _m66, twiss, _init_twiss)
     if r > 0:
-        raise _OpticsException(_trackcpp.string_error_messages[r])
+        raise _OpticsError(_trackcpp.string_error_messages[r])
 
     twiss = TwissArray(twiss, copy=False)
     m66 = _tracking._CppMatrix2Numpy(_m66)

--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -731,7 +731,8 @@ def find_orbit6(accelerator, indices=None, fixed_point_guess=None):
 
     # The orbit can't be found when quantum excitation is on.
     rad_stt = accelerator.radiation_on
-    accelerator.radiation_on = 'damping'
+    if rad_stt == accelerator.RadiationStates.Full:
+        accelerator.radiation_on = accelerator.RadiationStates.Damping
 
     if fixed_point_guess is None:
         fixed_point_guess = _trackcpp.CppDoublePos()

--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -61,9 +61,9 @@ class TrackingLossInfo:
                 None. If None, then associated attribute will not be created.
 
         """
-        self.lost_flag = _np.ndarray(lost_flag)
-        self.lost_plane = _np.ndarray(lost_plane)
-        self.lost_element = _np.ndarray(lost_element)
+        self.lost_flag = _np.array(lost_flag)
+        self.lost_plane = _np.array(lost_plane)
+        self.lost_element = _np.array(lost_element)
         self.lost_pos = lost_pos
         if lost_turn is not None:
             self.lost_turn = lost_turn

--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -947,14 +947,6 @@ def _get_slices_multiprocessing(parallel, nparticles):
     return [slice(parts_proc[i], parts_proc[i+1]) for i in range(nrproc)]
 
 
-def _CppMatrix2Numpy(_m):
-    return _np.array(_m)
-
-
-def _CppMatrix24Numpy(_m):
-    return _np.array(_m)[:4, :4]
-
-
 def _Numpy2CppDoublePos(p_in):
     p_out = _trackcpp.CppDoublePos(
         float(p_in[0]), float(p_in[1]),
@@ -977,36 +969,6 @@ def _CppDoublePos2Numpy(p_in):
 
 def _CppDoublePos24Numpy(p_in):
     return _np.array((p_in.rx, p_in.px, p_in.ry, p_in.py))
-
-
-def _Numpy2CppDoublePosVector(poss):
-    if isinstance(poss, _trackcpp.CppDoublePosVector):
-        return poss
-
-    conds = isinstance(poss, _np.ndarray)
-    conds &= len(poss.shape) == 2 and poss.shape[0] == 6
-    if not conds:
-        raise TrackingException('invalid positions argument')
-
-    poss_out = _trackcpp.CppDoublePosVector()
-    for pos in poss.T:
-        poss_out.push_back(_Numpy2CppDoublePos(pos))
-    return poss_out
-
-
-def _4Numpy2CppDoublePosVector(poss, de=0.0):
-    if isinstance(poss, _trackcpp.CppDoublePosVector):
-        return poss
-
-    conds = isinstance(poss, _np.ndarray)
-    conds &= len(poss.shape) == 2 and poss.shape[0] == 4
-    if not conds:
-        raise TrackingException('invalid positions argument')
-
-    poss_out = _trackcpp.CppDoublePosVector()
-    for pos in poss.T:
-        poss_out.push_back(_4Numpy2CppDoublePos(pos, de=de))
-    return poss_out
 
 
 def _CppDoublePosVector2Numpy(poss):
@@ -1073,24 +1035,3 @@ def _process_indices(accelerator, indices, closed=True, proc_none=True):
     else:
         raise TrackingError("invalid value for 'indices'")
     return indices
-
-
-def _print_CppDoublePos(pos):
-    print('\n{0:+.16f}'.format(pos.rx))
-    print('{0:+.16f}'.format(pos.px))
-    print('{0:+.16f}'.format(pos.ry))
-    print('{0:+.16f}'.format(pos.py))
-    print('{0:+.16f}'.format(pos.de))
-    print('{0:+.16f}\n'.format(pos.dl))
-
-
-# Legacy API
-elementpass = _utils.deprecated(element_pass)
-linepass = _utils.deprecated(line_pass)
-ringpass = _utils.deprecated(ring_pass)
-set4dtracking = _utils.deprecated(set_4d_tracking)
-set6dtracking = _utils.deprecated(set_6d_tracking)
-findorbit4 = _utils.deprecated(find_orbit4)
-findorbit6 = _utils.deprecated(find_orbit6)
-findm66 = _utils.deprecated(find_m66)
-findm44 = _utils.deprecated(find_m44)

--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -100,6 +100,36 @@ class TrackingLossInfo:
         """
         return _np.array(self.lost_flag).nonzero()[0]
 
+    def to_dict(self):
+        """."""
+        dic = {
+            'lost_flag': self.lost_flag,
+            'lost_plane': self.lost_plane,
+            'lost_element': self.lost_element,
+            'lost_pos': self.lost_pos,
+        }
+        if hasattr(self, 'lost_turn'):
+            dic['lost_turn'] = self.lost_turn
+        return dic
+
+    def from_dict(self, dic):
+        """."""
+        self.lost_flag = dic['lost_flag']
+        self.lost_plane = dic['lost_plane']
+        self.lost_element = dic['lost_element']
+        self.lost_pos = dic['lost_pos']
+        lost_turn = dic.get('lost_turn')
+        if lost_turn:
+            self.lost_turn = lost_turn
+
+    def __getstate__(self):
+        """."""
+        return self.to_dict()
+
+    def __setstate__(self, data):
+        """."""
+        self.from_dict(data)
+
 
 @_interactive
 def generate_bunch(

--- a/pyaccel/tracking.py
+++ b/pyaccel/tracking.py
@@ -163,15 +163,27 @@ def generate_bunch(
 
 
 @_interactive
-def set_4d_tracking(accelerator):
+def set_4d_tracking(accelerator: _Accelerator):
+    """Turn off radiation and cavity of accelerator.
+
+    Args:
+        accelerator (pyaccel.accelerator.Accelerator): accelerator object.
+    """
     accelerator.cavity_on = False
-    accelerator.radiation_on = 'off'
+    accelerator.radiation_on = 'Off'
 
 
 @_interactive
-def set_6d_tracking(accelerator, rad_full=False):
+def set_6d_tracking(accelerator: _Accelerator, rad_full=False):
+    """Turn on radiation and cavity of accelerator.
+
+    Args:
+        accelerator (_type_): accelerator object.
+        rad_full (bool, optional): whether to consider quantum excitation in
+            tracking. Defaults to False.
+    """
     accelerator.cavity_on = True
-    accelerator.radiation_on = 'full' if rad_full else 'damping'
+    accelerator.radiation_on = 'Full' if rad_full else 'Damping'
 
 
 @_interactive

--- a/pyaccel/utils.py
+++ b/pyaccel/utils.py
@@ -13,18 +13,9 @@ INTERACTIVE_LIST = []
 DISTRIBUTIONS_NAMES = _trackcpp.distributions_dict
 _states_str = tuple(state.upper() for state in _trackcpp.distributions_dict)
 _indices = (idx for idx in range(len(_states_str)))
-DISTRIBUTIONS_NAMES = _get_namedtuple('DISTRIBUTIONS_NAMES',
-    _states_str, _indices)
-del(_states_str)
-del(_indices)
-
-
-RADIATION_STATES_NAMES = _trackcpp.rad_dict
-_states_str = tuple(state.upper() for state in _trackcpp.rad_dict)
-_indices = (idx for idx in range(len(_states_str)))
-RADIATION_STATES = _get_namedtuple('RADIATION_STATES', _states_str, _indices)
-del(_states_str)
-del(_indices)
+DISTRIBUTIONS_NAMES = _get_namedtuple(
+    'DISTRIBUTIONS_NAMES', _states_str, _indices)
+del _states_str, _indices
 
 
 def interactive(obj):

--- a/test/test_tracking.py
+++ b/test/test_tracking.py
@@ -262,7 +262,7 @@ class TestTracking(unittest.TestCase):
             self.assertAlmostEqual(sum(r[0,:]),
                                    0.040352947331718, places=15)
 
-        except pyaccel.tracking.TrackingException:
+        except pyaccel.tracking.TrackingError:
             self.assertTrue(False)
 
 
@@ -302,7 +302,7 @@ class TestMatrixList(unittest.TestCase):
 
     def test_append_str(self):
         self.assertRaises(
-            pyaccel.tracking.TrackingException,
+            pyaccel.tracking.TrackingError,
             self.ml.append,
             ('matrix')
         )
@@ -345,7 +345,7 @@ class TestMatrixListInit(unittest.TestCase):
     def test_matrix_list_init_invalid_arg(self):
         ml_invalid = [self.m]
 
-        with self.assertRaises(pyaccel.tracking.TrackingException):
+        with self.assertRaises(pyaccel.tracking.TrackingError):
             pyaccel.tracking.MatrixList(ml_invalid)
 
 


### PR DESCRIPTION
# Description

This PR is the companion of lnls-fac/trackcpp#75, which is a retry of PR lnls-fac/trackcpp#74, based on the discussions raised there.
It adds the information of lost positions of tracked particles in `line_pass` and `ring_pass` as a separated output.

Besides this change, it also features:
 - `lost_flag` is now a list of booleans indicating whether each particle was lost;
 - `lost_turn` and `lost_element` are filled with `-1` for surviving particles;
 - fix bug in `line_pass` for parallel tracking with number of `particles > 1` but `<` than the number of processes.
 - Changes in `RadiationStates`: Now `RadiationStates` is a namedtuple defined in the `Accelerator` class. The options are also in title case;
 - Change name of Exceptions so that they finish with Error instead of Exception (linter suggestion);
 - Add `LossInfo` class to concentrate information about particle losses;
 - Fix `find_orbit6`: do not change `radiation_on` to `'Damping'` when it is `'Off'`;
 - Remove unused auxiliary functions and deprecated tracking functions: names such as `linepass`, `ringpass` and `elementpass` do not exist anymore;
 - Improve docstring of tracking functions.

# Tests

## Comparison of tracking results with master branch:
The following comparison was performed against the master branch of trackcpp and pyaccel:
The following code was run on both, master branch of trackcpp and pyaccel and this branch in pyaccel and the branch of lnls-fac/trackcpp#75:

```python3
import numpy as np
import pyaccel as pa
from mathphys.functions import load, save
from pymodels import si

mod = si.create_accelerator()
mod = si.fitted_models.vertical_dispersion_and_coupling(mod)
mod.cavity_on = True
mod.radiation_on = 0
mod.vchamber_on = True
print(mod)

eqpar = pa.optics.EqParamsFromBeamEnvelope(mod)
np.random.seed(2030948)
parts = pa.tracking.generate_bunch(1000, eqpar.envelopes[0]*(8e-3/65e-6)**2)
out_line = pa.tracking.line_pass(
    mod, parts, indices='closed', element_offset=0, parallel=True,
)
out_ring = pa.tracking.ring_pass(
    mod, parts, nr_turns=10, turn_by_turn=True, element_offset=0, parallel=True
)
# on this branch
save(out_line, 'sirius_dev_line', overwrite=True)
save(out_ring, 'sirius_dev_ring', overwrite=True)
# on master branch
# save(out_line, 'sirius_mas_line', overwrite=True)
# save(out_ring, 'sirius_mas_ring', overwrite=True)
```

then, the following comparison was made (must be in the current branches of this PR):
```python3
import numpy as np
from mathphys.functions import load, save

out_dev_line = load('sirius_dev_line')
out_dev_ring = load('sirius_dev_ring')
out_mas_line = load('sirius_mas_line')
out_mas_ring = load('sirius_mas_ring')

print(out_mas_line[0].tobytes() == out_dev_line[0].tobytes())
print(out_mas_ring[0].tobytes() == out_dev_ring[0].tobytes())
```
and the equalities hold.

## Test of output shapes:
I also performed a test to check if the shape of the tracking results and the lost positions were consistent when different parameters of the tracking functions were used. The following code was used:
```python3
from itertools import product

import numpy as np
import pyaccel as pa
from mathphys.functions import load, save
from pymodels import si

mod = si.create_accelerator()
mod = si.fitted_models.vertical_dispersion_and_coupling(mod)
mod.cavity_on = True
mod.radiation_on = 0
mod.vchamber_on = True
print(mod)

parts = np.array([
    [-11.8e-3, 1e-5, 0, 0, 0, 0],
    [1e-4, 0, 0, 0, 0, 0]
]).T

print('ring_pass')
idcs = True, False
para = True, False
nrpt = 1, 2
for idx, par, nrp in product(idcs, para, nrpt):
    out = pa.tracking.ring_pass(
        mod, parts[:, :nrp], nr_turns=2, turn_by_turn=idx, element_offset=0, parallel=par
    )
    print(
        idx,
        par,
        nrp,
        out[0].shape,
        out[1].lost_pos.shape,
    )
print('line_pass')
idcs = 'closed', None
para = True, False
nrpt = 1, 2
for idx, par, nrp in product(idcs, para, nrpt):
    out = pa.tracking.line_pass(
        mod, parts[:, :nrp], indices=idx, element_offset=0, parallel=par,
    )
    print(
        idx,
        par,
        nrp,
        out[0].shape,
        out[1].lost_pos.shape
    )
```
resulting in:
```
ring_pass
True True 1 (6, 3) (6,)
True True 2 (6, 2, 3) (6, 2)
True False 1 (6, 3) (6,)
True False 2 (6, 2, 3) (6, 2)
False True 1 (6,) (6,)
False True 2 (6, 2) (6, 2)
False False 1 (6,) (6,)
False False 2 (6, 2) (6, 2)
line_pass
closed True 1 (6, 6550) (6,)
closed True 2 (6, 2, 6550) (6, 2)
closed False 1 (6, 6550) (6,)
closed False 2 (6, 2, 6550) (6, 2)
None True 1 (6,) (6,)
None True 2 (6, 2) (6, 2)
None False 1 (6,) (6,)
None False 2 (6, 2) (6, 2)
```
