### PR TITLE
Add calculation of first order resonance driving terms

### DIFF
--- a/pyaccel/lattice.py
+++ b/pyaccel/lattice.py
@@ -159,7 +159,7 @@ def split_element(element, fractions=None, nr_segs=None):
         fractions = _np.ones(nr_segs)/nr_segs
 
     try:
-        fractions = _np.asarray(fractions, dtype=float)
+        fractions = _np.array(fractions, dtype=float)
         if fractions.size <= 1:
             raise ValueError('')
     except ValueError:

--- a/pyaccel/optics/__init__.py
+++ b/pyaccel/optics/__init__.py
@@ -11,3 +11,4 @@ from .eq_params import EqParamsXYModes, EqParamsNormalModes
 from .rad_integrals import EqParamsFromRadIntegrals
 from .beam_envelope import EqParamsFromBeamEnvelope, calc_beamenvelope
 from .twiss import Twiss, TwissArray, calc_twiss
+from .driving_terms import FirstOrderDrivingTerms

--- a/pyaccel/optics/driving_terms.py
+++ b/pyaccel/optics/driving_terms.py
@@ -1,0 +1,178 @@
+"""Calculate Resonance Driving Terms."""
+
+import numpy as _np
+
+from .twiss import calc_twiss as _calc_twiss
+from .. import lattice as _lattice
+
+
+class FirstOrderDrivingTerms:
+    """Calculate first order resonance driving terms."""
+
+    AchromaticTerms = (
+        "h10020", "h10110", "h10200", "h21000", "h30000", 
+    )
+    ChromaticTerms = (
+        "h11001", "h00111", "h20001", "h00201", "h10002",
+    )
+
+    def __init__(self, accelerator, num_segments=2, energy_offset=0.0):
+        """."""
+        self._num_segments = num_segments
+        self._accelerator = accelerator
+        self._energy_offset = energy_offset
+        self._driving_terms = dict()
+        self._update_driving_terms()
+
+    @property
+    def accelerator(self):
+        """."""
+        return self._accelerator
+
+    @accelerator.setter
+    def accelerator(self, acc):
+        """."""
+        self._accelerator = acc
+        self._update_driving_terms()
+
+    @property
+    def num_segments(self):
+        """."""
+        return self._num_segments
+
+    @num_segments.setter
+    def num_segments(self, num_segs):
+        """."""
+        self._num_segments = int(num_segs)
+        self._update_driving_terms()
+
+    @property
+    def energy_offset(self):
+        """."""
+        return self._energy_offset
+
+    @energy_offset.setter
+    def energy_offset(self, val):
+        """."""
+        self._energy_offset = float(val)
+        self._update_driving_terms()
+
+    @property
+    def h11001(self):
+        """."""
+        return self._driving_terms["h11001"]
+
+    @property
+    def h00111(self):
+        """."""
+        return self._driving_terms["h00111"]
+
+    @property
+    def h20001(self):
+        """."""
+        return self._driving_terms["h20001"]
+
+    @property
+    def h00201(self):
+        """."""
+        return self._driving_terms["h00201"]
+
+    @property
+    def h10002(self):
+        """."""
+        return self._driving_terms["h10002"]
+
+    @property
+    def h21000(self):
+        """."""
+        return self._driving_terms["h21000"]
+
+    @property
+    def h30000(self):
+        """."""
+        return self._driving_terms["h30000"]
+
+    @property
+    def h10110(self):
+        """."""
+        return self._driving_terms["h10110"]
+
+    @property
+    def h10200(self):
+        """."""
+        return self._driving_terms["h10200"]
+
+    @property
+    def h10020(self):
+        """."""
+        return self._driving_terms["h10020"]
+
+    def _update_driving_terms(self):
+        quads = _np.array(_lattice.get_attribute(self._accelerator, 'KL'))
+        sexts = _np.array(_lattice.get_attribute(self._accelerator, 'SL'))
+        idcs = ~_np.isclose(quads, 0) & ~_np.isclose(sexts, 0)
+        idcs = idcs.nonzero()[0]
+        quads = quads[idcs] / self._num_segments
+        sexts = sexts[idcs] / self._num_segments
+
+        # Refine the lattice at the components that generate driving terms
+        # The segmentation has to be in a way that the twiss functions are
+        # calculated at the center of the slice. For instance, lets suppose
+        # we will divide a given component in 3 equal contributions:
+        #   :  first segment  : second segment  :  third segment  :
+        #    ********|********:********|********:********|********
+        #   ^        ^                 ^                 ^        ^
+        # start twiss needed      twiss needed     twiss needed  end 
+        fractions = _np.r_[1, _np.ones(self._num_segments-1)*2, 1]
+        fractions /= fractions.sum()
+        acc = _lattice.refine_lattice(
+            self._accelerator, indices=idcs, fractions=fractions
+        )
+        
+        # get the indices
+        _quads = _np.array(_lattice.get_attribute(acc, 'KL'))
+        _sexts = _np.array(_lattice.get_attribute(acc, 'SL'))
+        _idcs = ~_np.isclose(_quads, 0) & ~_np.isclose(_sexts, 0)
+        _idcs = _idcs.nonzero()[0]
+        _idcs = _idcs.reshape(idcs.size, -1)[:, 1:].ravel()
+
+        quads = _np.tile(quads, (self._num_segments, 1)).T.ravel()
+        sexts = _np.tile(sexts, (self._num_segments, 1)).T.ravel()
+        twiss, *_ = _calc_twiss(
+            acc, indices=_idcs, energy_offset=self._energy_offset
+        )
+        hx = _np.exp(1j*twiss.mux)
+        hx2 = hx * hx
+        hy2 = _np.exp(2j*twiss.muy)
+        btx = twiss.betax
+        bty = twiss.betay
+        etx = twiss.etax
+
+        setx = sexts * etx
+        h11001 = +1/4 * (quads - 2 * setx) * btx
+        h00111 = -1/4 * (quads - 2 * setx) * bty
+        dr_terms = dict(
+            h11001=h11001,
+            h00111=h00111,
+            h20001=h11001 * hx2 / 2,
+            h00201=h00111 * hy2 / 2,
+            h10002=1/2 * (quads - setx) * etx * _np.sqrt(btx) * hx,
+        )
+        
+        sbx = -1/8 * sexts * _np.sqrt(btx) * hx
+        sbxbx = sbx * btx
+        sbxby = -1 * sbx * bty
+        dr_terms.update(dict(
+            h21000=sbxbx,
+            h30000=sbxbx * hx2 / 3,
+            h10110=2 * sbxby,
+            h10200=sbxby * hy2,
+            h10020=sbxby / hy2,
+        ))
+
+        for k, val in dr_terms.items():
+            drt = _np.zeros(len(self._accelerator)+1, dtype=complex)
+            drt[idcs] = val.reshape(idcs.size, -1).sum(axis=1)
+            dr_terms[k] = _np.cumsum(drt)
+        
+        self._driving_terms = dr_terms

--- a/pyaccel/optics/driving_terms.py
+++ b/pyaccel/optics/driving_terms.py
@@ -9,7 +9,11 @@ from .twiss import calc_twiss as _calc_twiss
 
 
 class FirstOrderDrivingTerms:
-    """Calculate first order resonance driving terms."""
+    """Calculate first order resonance driving terms.
+
+    The implementation is based on Bengtsson report:
+        https://ados.web.psi.ch/slsnotes/sls0997.pdf
+    """
 
     GeometricTerms = "h10020", "h10110", "h10200", "h21000", "h30000"
     ChromaticTerms = "h11001", "h00111", "h20001", "h00201", "h10002"


### PR DESCRIPTION
For now, only normal sextupolar driving terms are being computed.

Running the following code:
```python3
import numpy as np
import matplotlib.pyplot as mplt
import pyaccel as pa
from pymodels import si

mod = si.create_accelerator()
rdts = pa.optics.FirstOrderDrivingTerms(mod, num_segments=10, energy_offset=0.0)
fig, axs = rdts.plot_rdt_along_ring(geometric=True, symmetry=5)
fig.show()
fig, axs = rdts.plot_rdt_along_ring(geometric=False, symmetry=5)
fig.show()

fig, ax = rdts.plot_one_turn_rdts(geometric=True)
fig.show()
fig, ax = rdts.plot_one_turn_rdts(geometric=False)
fig.show()

print(-rdts.h11001[-1] / np.pi, -rdts.h00111[-1] / np.pi)
print(pa.optics.miscellaneous.get_chromaticities(mod))
```

will result in:
```
(2.5399940500906566-0j) (2.50703643220055-0j)
(2.5399182477375826, 2.521281232903405)
```

![image](https://github.com/user-attachments/assets/af377086-d9ef-4001-8eb4-7044a479ccfd)
![image](https://github.com/user-attachments/assets/4879f54f-f7da-40e3-95b0-ed0b1c77e071)

![image](https://github.com/user-attachments/assets/30b17994-bc55-450f-96cf-675dd303e371) ![image](https://github.com/user-attachments/assets/ed05ca25-8336-47af-bb7d-5258b839b27e)
