### PR TITLE
Match Trackcpp Required Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 from distutils.version import StrictVersion
 
 
-trackcpp_version = '4.10.6'
+trackcpp_version = '4.10.5'
 
 try:
     import trackcpp


### PR DESCRIPTION
Trackcpp's current version (05-september-2024, 05:34 pm) is `4.10.5`. 
This PR fix the minimun required version `4.10.6` -> `4.10.5`.