### PR TITLE
Standardize default energy offset in optics module

### DIFF
--- a/pyaccel/optics/edwards_teng.py
+++ b/pyaccel/optics/edwards_teng.py
@@ -671,7 +671,7 @@ def calc_edwards_teng(
 
     cod = None
     if init_edteng is not None:
-        if energy_offset is not None:
+        if energy_offset:
             # Turn cavity and radiation states back to their original values.
             accelerator.cavity_on = cav_stt
             accelerator.radiation_on = rad_stt

--- a/pyaccel/optics/edwards_teng.py
+++ b/pyaccel/optics/edwards_teng.py
@@ -622,7 +622,7 @@ class EdwardsTengArray(_np.ndarray):
 @_interactive
 def calc_edwards_teng(
         accelerator=None, init_edteng=None, indices='open',
-        energy_offset=None):
+        energy_offset=0.0):
     """Perform linear analysis of coupled lattices.
 
     Notation is the same as in reference [3]

--- a/pyaccel/optics/edwards_teng.py
+++ b/pyaccel/optics/edwards_teng.py
@@ -642,11 +642,8 @@ def calc_edwards_teng(
 
     Args:
         accelerator (pyaccel.accelerator.Accelerator): lattice model
-        energy_offset (float, optional): Energy Offset . Defaults to 0.0.
         init_edteng (pyaccel.optics.EdwardsTeng, optional): EdwardsTeng
             parameters at the start of first element. Defaults to None.
-        energy_offset (float, optional): float denoting the energy deviation
-            (used only for periodic solutions). Defaults to None.
         indices : may be a ((list, tuple, numpy.ndarray), optional):
             list of element indices where closed orbit data is to be
             returned or a string:
@@ -656,6 +653,8 @@ def calc_edwards_teng(
                     element.
             If indices is None data will be returned only at the entrance
             of the first element. Defaults to 'open'.
+        energy_offset (float, optional): float denoting the energy deviation
+            (used only for periodic solutions). Defaults to 0.0.
 
     Returns:
         pyaccel.optics.EdwardsTengArray : array of decompositions of the

--- a/pyaccel/optics/edwards_teng.py
+++ b/pyaccel/optics/edwards_teng.py
@@ -662,6 +662,31 @@ def calc_edwards_teng(
         numpy.ndarray (4x4): transfer matrix of the line/ring
 
     """
+    # TODO:
+    # Inconsistencies found when comparing optics obtained by providing
+    # `calc_edwards_teng` with an energy-offset vs those obtained by providing
+    # the function with an initial edteng object.
+    # The snipped below should replicate the discrepancies:
+
+    # >> import numpy as np
+    # >> import pyaccel as pa
+    # >> from pymodels import si
+    # >> model = si.create_accelerator()
+    # >> model = si.fitted_models.vertical_dispersion_and_coupling(model)
+    # >> init_edteng = pa.optics.calc_edwards_teng(
+    # >>    model, energy_offset=1e-2
+    # >> )[0][0]
+    # >> edteng, _ = pa.optics.calc_edwards_teng(
+    # >>    model, energy_offset=1e-2
+    # >> )
+    # >> edteng_, _ = pa.optics.calc_edwards_teng(
+    # >>    model, init_edteng=init_edteng
+    # >> )
+    # >> np.allclose(edteng.beta1, edteng_.beta1)
+    # >> False
+    # >> np.allclose(edteng.eta1, edteng_.eta1)
+    # >> False
+
     # Since Edwards and Teng decomposition is restricted to Symplectic 4D
     # motion, we need to turn off cavity and radiation here:
     cav_stt = accelerator.cavity_on

--- a/pyaccel/optics/twiss.py
+++ b/pyaccel/optics/twiss.py
@@ -443,8 +443,7 @@ def calc_twiss(
         if fixed_point is None:
             _closed_orbit = _trackcpp.CppDoublePosVector()
             _fixed_point_guess = _trackcpp.CppDoublePos()
-            if energy_offset is not None:
-                _fixed_point_guess.de = energy_offset
+            _fixed_point_guess.de = energy_offset
 
             if not accelerator.cavity_on and not accelerator.radiation_on:
                 r = _trackcpp.track_findorbit4(
@@ -465,8 +464,7 @@ def calc_twiss(
 
         else:
             _fixed_point = _tracking._Numpy2CppDoublePos(fixed_point)
-            if energy_offset is not None:
-                _fixed_point.de = energy_offset
+            _fixed_point.de = energy_offset
 
         _init_twiss = _trackcpp.Twiss()
 

--- a/pyaccel/optics/twiss.py
+++ b/pyaccel/optics/twiss.py
@@ -408,7 +408,7 @@ def calc_twiss(
             first element. Defaults to None.
         indices (str, optional): 'open' or 'closed'. Defaults to 'open'.
         energy_offset (float, optional): float denoting the energy deviation
-            (used only for periodic solutions). Defaults to None.
+            (used only for periodic solutions). Defaults to 0.0.
 
     Raises:
         pyaccel.tracking.TrackingError: When find_orbit fails to converge.

--- a/pyaccel/optics/twiss.py
+++ b/pyaccel/optics/twiss.py
@@ -397,7 +397,7 @@ class TwissArray(_np.ndarray):
 @_interactive
 def calc_twiss(
         accelerator=None, init_twiss=None, fixed_point=None,
-        indices='open', energy_offset=None):
+        indices='open', energy_offset=0.0):
     """Return Twiss parameters of uncoupled dynamics.
 
     Args:


### PR DESCRIPTION
When trying to calculate optics with `calc_edwards_teng`, I was getting bugs related to the default `None`-type energy-deviation. As in #149, I standardized `energy-offset` to `0.0`. I also did it for `calc_twiss`, despite the `None`-type not being a problem there. 

Additionally, I use this PR to highlight an issue I found during some tests. There are inconsistencies between the optics obtained by providing `calc_edwards_teng` with an energy-offset vs those obtained by providing the function with an initial edteng object. The snipped below should replicate the discrepancies:

```python
import numpy as np
import pyaccel as pa
from pymodels import si

model = si.create_accelerator()
model = si.fitted_models.vertical_dispersion_and_coupling(model)

init_edteng = pa.optics.calc_edwards_teng( model, energy_offset=1e-2)[0][0]
edteng, _ = pa.optics.calc_edwards_teng(energy_offset=1e-2)
edteng_, _ = pa.optics.calc_edwards_teng(model, init_edteng=init_edteng)
np.allclose(edteng.beta1, edteng_.beta1)
np.allclose(edteng.eta1, edteng_.eta1)
```
The last two commands should return `False`. 