### PR TITLE
Complete pyaccel import

### DIFF
--- a/pyaccel/__init__.py
+++ b/pyaccel/__init__.py
@@ -1,5 +1,6 @@
 """Pyaccel package."""
 
+# modules
 from . import elements
 from . import accelerator
 from . import lattice
@@ -10,6 +11,14 @@ from . import lifetime
 from . import naff
 from . import utils
 
+# subpackages
+from . import optics
+
 import os as _os
 with open(_os.path.join(__path__[0], 'VERSION'), 'r') as _f:
     __version__ = _f.read().strip()
+
+__all__ = ['elements', 'accelerator', 'lattice', 'tracking', 'graphics',
+           'intrabeam_scattering', 'lifetime', 'naff', 'utils', '__version__']
+
+__all__.extend(['optics'])

--- a/pyaccel/optics/__init__.py
+++ b/pyaccel/optics/__init__.py
@@ -12,3 +12,13 @@ from .miscellaneous import get_chromaticities, get_curlyh, get_frac_tunes, \
     get_rf_frequency, get_rf_voltage, OpticsError
 from .rad_integrals import EqParamsFromRadIntegrals
 from .twiss import calc_twiss, Twiss, TwissArray
+
+__all__ = ['calc_touschek_energy_acceptance', 'calc_transverse_acceptance',
+           'calc_beamenvelope', 'EqParamsFromBeamEnvelope',
+           'FirstOrderDrivingTerms', 'calc_edwards_teng', 'EdwardsTeng',
+           'EdwardsTengArray', 'estimate_coupling_parameters',
+           'EqParamsNormalModes', 'EqParamsXYModes', 'get_chromaticities',
+           'get_curlyh', 'get_frac_tunes', 'get_mcf',
+           'get_revolution_frequency', 'get_revolution_period',
+           'get_rf_frequency', 'get_rf_voltage', 'OpticsError',
+           'EqParamsFromRadIntegrals', 'calc_twiss', 'Twiss', 'TwissArray']


### PR DESCRIPTION
This PR fixes the missing import of the subpackage `optics` in `pyaccel.__init__`.